### PR TITLE
Add --resolve option

### DIFF
--- a/src/host.h
+++ b/src/host.h
@@ -102,6 +102,8 @@ bool is_valid_ip_address (const char *name);
 bool accept_domain (struct url *);
 bool sufmatch (const char **, const char *);
 
+bool cache_host_ip (const char *, const char *);
+
 void host_cleanup (void);
 
 #endif /* HOST_H */

--- a/src/main.c
+++ b/src/main.c
@@ -416,6 +416,7 @@ static struct cmdline_option option_data[] =
     { "remote-encoding", 0, OPT_VALUE, "remoteencoding", -1 },
     { "remove-listing", 0, OPT_BOOLEAN, "removelisting", -1 },
     { "report-speed", 0, OPT_BOOLEAN, "reportspeed", -1 },
+    { "resolve", 0, OPT_VALUE, "resolve", -1 },
     { "restrict-file-names", 0, OPT_BOOLEAN, "restrictfilenames", -1 },
     { "retr-symlinks", 0, OPT_BOOLEAN, "retrsymlinks", -1 },
     { "retry-connrefused", 0, OPT_BOOLEAN, "retryconnrefused", -1 },
@@ -711,6 +712,9 @@ Download:\n"),
        --limit-rate=RATE           limit download rate to RATE\n"),
     N_("\
        --no-dns-cache              disable caching DNS lookups\n"),
+    N_("\
+       --resolve=HOST:IP           set hostname to IP resolution. \n\
+                                     Note: this option is incompatible with --no-dns-cache.\n"),
     N_("\
        --restrict-file-names=OS    restrict chars in file names to ones OS allows\n"),
     N_("\
@@ -1646,6 +1650,13 @@ main (int argc, char **argv)
     {
       fprintf (stderr, _("\
 Can't timestamp and not clobber old files at the same time.\n"));
+      print_usage (1);
+      exit (WGET_EXIT_GENERIC_ERROR);
+    }
+  if (!opt.dns_cache && opt.resolve)
+    {
+      fprintf (stderr, _("\
+Cannot set resolve and disable DNS cache at the same time.\n"));
       print_usage (1);
       exit (WGET_EXIT_GENERIC_ERROR);
     }

--- a/src/options.h
+++ b/src/options.h
@@ -110,6 +110,8 @@ struct options
   char **exclude_domains;
   bool dns_cache;               /* whether we cache DNS lookups. */
 
+  bool resolve;                 /* Whether DNS host resolution is overriden for some hosts. */
+
   char **follow_tags;           /* List of HTML tags to recursively follow. */
   char **ignore_tags;           /* List of HTML tags to ignore if recursing. */
 

--- a/testenv/Test--resolve.py
+++ b/testenv/Test--resolve.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+from sys import exit
+from test.http_test import HTTPTest
+from misc.wget_file import WgetFile
+
+"""
+    This test ensures that Wget correctly handles overriding DNS resolution
+    for domain name.
+"""
+############# File Definitions ###############################################
+File1 = "dummy"
+
+A_File = WgetFile ("File1", File1)
+
+WGET_OPTIONS = "--resolve=example.com:127.0.0.1"
+WGET_URLS = [["File1"]]
+
+Files = [[A_File]]
+
+ExpectedReturnCode = 0
+ExpectedDownloadedFiles = [A_File]
+
+################ Pre and Post Test Hooks #####################################
+pre_test = {
+    "ServerFiles"       : Files,
+}
+test_options = {
+    "WgetCommands"      : WGET_OPTIONS,
+    "Urls"              : WGET_URLS
+}
+post_test = {
+    "ExpectedFiles"     : ExpectedDownloadedFiles,
+    "ExpectedRetcode"   : ExpectedReturnCode
+}
+
+err = HTTPTest (
+                pre_hook=pre_test,
+                test_params=test_options,
+                post_hook=post_test
+).begin ()
+
+exit (err)

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -114,6 +114,7 @@ PX_TESTS = \
              Test-proxied-https-auth.px \
              Test-proxied-https-auth-keepalive.px \
              Test-proxy-auth-basic.px \
+             Test--resolve.px \
              Test-restrict-ascii.px \
              Test-Restrict-Lowercase.px \
              Test-Restrict-Uppercase.px \

--- a/tests/Test--resolve.px
+++ b/tests/Test--resolve.px
@@ -1,0 +1,40 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+use POSIX;
+use Socket;
+
+use HTTPTest;
+
+
+###############################################################################
+
+# code, msg, headers, content
+my %urls = (
+    '/dummy' => {
+        code => "204",
+        msg => "Dontcare",
+    },
+);
+
+my $resolved_host = "example.com";
+my $localip = "::1";
+
+my $cmdline = $WgetTest::WGETPATH . " --resolve $resolved_host:$localip"
+    . " http://$resolved_host:{{port}}/dummy";
+
+my $expected_error_code = 0;
+
+my %expected_downloaded_files = (
+);
+
+###############################################################################
+
+my $the_test = HTTPTest->new (input => \%urls,
+                              cmdline => $cmdline,
+                              errcode => $expected_error_code,
+                              output => \%expected_downloaded_files);
+exit $the_test->run();
+
+# vim: et ts=4 sw=4

--- a/tests/unit-tests.c
+++ b/tests/unit-tests.c
@@ -59,6 +59,7 @@ all_tests(void)
   mu_run_test (test_append_uri_pathel);
   mu_run_test (test_are_urls_equal);
   mu_run_test (test_is_robots_txt_url);
+  mu_run_test (test_resolve_argument_parse);
 #ifdef HAVE_HSTS
   mu_run_test (test_hsts_new_entry);
   mu_run_test (test_hsts_url_rewrite_superdomain);

--- a/tests/unit-tests.h
+++ b/tests/unit-tests.h
@@ -61,6 +61,7 @@ const char *test_hsts_new_entry(void);
 const char *test_hsts_url_rewrite_superdomain(void);
 const char *test_hsts_url_rewrite_congruent(void);
 const char *test_hsts_read_database(void);
+const char *test_resolve_argument_parse(void);
 
 #endif /* TEST_H */
 


### PR DESCRIPTION
Add option `--resolve=HOST:IP` to manually associate host name DNS resolution. Intended to be like a `curl --resolve` option.

Example:
```
wget --resolve example.com:127.0.0.1 http://example.com/
```
or IPv6:
```
wget --resolve example.com:::1 http://example.com/
```
