### PR TITLE
Change quote to quote_n as quote reuses storage that it returns

### DIFF
--- a/src/ftp.c
+++ b/src/ftp.c
@@ -2352,15 +2352,15 @@ The sizes do not match (local %s) -- retrieving.\n\n"),
                             {
                               logprintf (LOG_VERBOSE, _("\
 Already have correct symlink %s -> %s\n\n"),
-                                         quote (con->target),
-                                         quote (f->linkto));
+                                         quote_n (0, con->target),
+                                         quote_n (1, f->linkto));
                               dlthis = false;
                               break;
                             }
                         }
                     }
                   logprintf (LOG_VERBOSE, _("Creating symlink %s -> %s\n"),
-                             quote (con->target), quote (f->linkto));
+                             quote_n (0, con->target), quote_n (1, f->linkto));
                   /* Unlink before creating symlink!  */
                   unlink (con->target);
                   if (symlink (f->linkto, con->target) == -1)

--- a/src/iri.c
+++ b/src/iri.c
@@ -138,7 +138,7 @@ do_conversion (const char *tocode, const char *fromcode, char const *in_org, siz
   if (cd == (iconv_t)(-1))
     {
       logprintf (LOG_VERBOSE, _("Conversion from %s to %s isn't supported\n"),
-                 quote (fromcode), quote (tocode));
+                 quote_n (0, fromcode), quote_n (1, tocode));
       *out = NULL;
       return false;
     }

--- a/src/url.c
+++ b/src/url.c
@@ -1585,7 +1585,7 @@ convert_fname (char *fname)
   if (cd == (iconv_t) (-1))
     {
       logprintf (LOG_VERBOSE, _ ("Conversion from %s to %s isn't supported\n"),
-                 quote (from_encoding), quote (to_encoding));
+                 quote_n (0, from_encoding), quote_n (1, to_encoding));
       return fname;
     }
 


### PR DESCRIPTION
https://www.gnu.org/software/gnulib/manual/html_node/Quoting.html
>if you need more than one thing quoted at the same time, you need to use quote_n.